### PR TITLE
a bug on softamx and K.set_image_data_format("channels_first")

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,14 @@ X, Y = your_data_loader()
 # prepare the 3D model
 from unet3d import *
 input_channels, input_rows, input_cols, input_deps = 1, 64, 64, 32
-num_class, activate = 2, 'softmax'
+num_class, activate = 2, keras.activations.softmax
 weight_dir = 'pretrained_weights/Genesis_Chest_CT.h5'
 models_genesis = unet_model_3d((input_channels, input_rows, input_cols, input_deps), batch_normalization=True)
 print("Load pre-trained Models Genesis weights from {}".format(weight_dir))
 models_genesis.load_weights(weight_dir)
 x = models_genesis.get_layer('depth_13_relu').output
 final_convolution = Conv3D(num_class, (1, 1, 1))(x)
-output = Activation(activate)(final_convolution)
+output = activate(final_convolution, axis=1)
 model = keras.models.Model(inputs=models_genesis.input, outputs=output)
 models.compile(optimizer="adam", loss=dice_coef_loss, metrics=[mean_iou,dice_coef])
 


### PR DESCRIPTION
Hi Zhou, 

We have been trying your amazing code for days, thanks for your work!

We found a bug on your README on how to use your pretrained model for segmentation.

Your model code define a channel-first implementation
```python
K.set_image_data_format("channels_first")
```
, where inputs: `B x C x D x H x W`. Thereby, your output `final_convolution` is also `B x C x D x H x W`.

If you run.
```python
output = Activation('softmax')(final_convolution)
```
The default `softmax` is compute the normalized term on the `axis=-1`, i.e. the `W`-axis, which is usually not what people want.